### PR TITLE
ci(deploy): give write permission to action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+permissions: write-all
 
 jobs:
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   test:


### PR DESCRIPTION
This allows the deploy job to actually push to `gh-pages`.