### PR TITLE
style: disable quirks mode in demo and tests

### DIFF
--- a/demo/embedded.html
+++ b/demo/embedded.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <title>OpenSCD Core Embedding Demo</title>
 <iframe src="./index.html?locale=de&dark"></iframe>
 <style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <title>OpenSCD Core Demo</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300&family=Roboto:wght@300;400;500&display=swap">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block">

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -77,6 +77,7 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
       name: 'visual',
       files: 'dist/**/*.test.js',
       testRunnerHtml: testFramework => `
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300&family=Roboto:wght@300;400;500&display=swap">
@@ -122,8 +123,9 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
       padding: 0px;
     }
 
-    body {
-      background: white;
+    open-scd {
+      display: block;
+      height: 600px;
     }
     </style>
   </body>


### PR DESCRIPTION
Adds doctype to local demo and test html files in order to prevent accidental dependence on the deprecated CSS "quirks mode".