### PR TITLE
chore: fix bundler

### DIFF
--- a/open-scd.ts
+++ b/open-scd.ts
@@ -73,7 +73,7 @@ const { getLocale, setLocale } = configureLocalization({
   sourceLocale,
   targetLocales,
   loadLocale: locale =>
-    import(new URL(`locales/${locale}.js`, import.meta.url).href),
+    import(new URL(`./locales/${locale}.js`, import.meta.url).href),
 });
 
 function describe({ undo, redo }: LogEntry) {


### PR DESCRIPTION
Fixes a bug in rollup that came from a relative path in a dynamic import that didn't start with a dot, something that rollup apparently cannot handle.